### PR TITLE
Added support to leave unmasked characters from the beginning of the String

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,16 @@ And it will produce:
 }
 ```
 Furthermore, you can customize the masking character and if you want to 
-leave some last characters. 
+leave some forst and last characters. 
 ```java
-    @MaskString(keepLastCharacters = 6, maskCharacter = '-')
+    @MaskString(keepFirstCharacters = 1, keepLastCharacters = 4, maskCharacter = '-')
     String id;
 ```
 
 The produced json in this case would be:
 ```json
 {
-  "id": "--cd1234"
+  "id": "a---1234"
 }
 ```
 

--- a/src/main/java/com/github/javiercanillas/jackson/masker/annotation/MaskString.java
+++ b/src/main/java/com/github/javiercanillas/jackson/masker/annotation/MaskString.java
@@ -27,12 +27,20 @@ import java.lang.annotation.Target;
 public @interface MaskString {
     int DEFAULTS_KEEP_LAST_CHARACTERS = MaskUtils.DEFAULTS_KEEP_LAST_CHARACTERS;
     char DEFAULTS_MASK_CHARACTER = MaskUtils.DEFAULT_MASK_CHARACTER;
+    int DEFAULTS_KEEP_FIRST_CHARACTERS = MaskUtils.DEFAULTS_KEEP_FIRST_CHARACTERS;
 
     /**
      * Character to be used for masker. Defaults to {@link MaskString#DEFAULTS_MASK_CHARACTER} if none is set.
      * @return char to be used to replace masked positions
      */
     char maskCharacter() default DEFAULTS_MASK_CHARACTER;
+
+    /**
+     * Quantity of beginning characters to left unmasked. Defaults to {@link MaskString#DEFAULTS_KEEP_FIRST_CHARACTERS}
+     * if none is set. Only a ZERO or POSITIVE values are allowed.
+     * @return quantity of characters to leave unmasked
+     */
+    int keepFirstCharacters() default DEFAULTS_KEEP_FIRST_CHARACTERS;
 
     /**
      * Quantity of final characters to left unmasked. Defaults to {@link MaskString#DEFAULTS_KEEP_LAST_CHARACTERS}

--- a/src/main/java/com/github/javiercanillas/jackson/masker/ser/MaskStringSerializer.java
+++ b/src/main/java/com/github/javiercanillas/jackson/masker/ser/MaskStringSerializer.java
@@ -32,6 +32,8 @@ public class MaskStringSerializer extends JsonSerializer<Object> implements Cont
     @Getter
     private final JsonSerializer<Object> nonMaskerSerializer;
     @Getter
+    private final int keepFirstCharacters;
+    @Getter
     private final int keepLastCharacters;
     @Getter
     private final char maskCharacter;
@@ -41,11 +43,13 @@ public class MaskStringSerializer extends JsonSerializer<Object> implements Cont
      * serialization.
      */
     public MaskStringSerializer() {
-        this(null, MaskString.DEFAULTS_KEEP_LAST_CHARACTERS, MaskString.DEFAULTS_MASK_CHARACTER);
+        this(null, MaskString.DEFAULTS_KEEP_FIRST_CHARACTERS, MaskString.DEFAULTS_KEEP_LAST_CHARACTERS, MaskString.DEFAULTS_MASK_CHARACTER);
     }
 
-    public MaskStringSerializer(final JsonSerializer<Object> nonMaskerSerializer, final int keepLastCharacters, final char maskCharacter) {
+    public MaskStringSerializer(final JsonSerializer<Object> nonMaskerSerializer, final int keepFirstCharacters,
+                                final int keepLastCharacters, final char maskCharacter) {
         this.nonMaskerSerializer = nonMaskerSerializer;
+        this.keepFirstCharacters = keepFirstCharacters;
         this.keepLastCharacters = keepLastCharacters;
         this.maskCharacter = maskCharacter;
     }
@@ -115,6 +119,7 @@ public class MaskStringSerializer extends JsonSerializer<Object> implements Cont
     public JsonSerializer<?> createContextual(final SerializerProvider serializers, final BeanProperty property) throws JsonMappingException {
         var annotation = Optional.ofNullable(property).map(prop -> prop.getAnnotation(MaskString.class));
         return new MaskStringSerializer(serializers.findValueSerializer(property.getType(), property),
+                Math.max(0, annotation.map(MaskString::keepFirstCharacters).orElse(MaskString.DEFAULTS_KEEP_FIRST_CHARACTERS)),
                 Math.max(0, annotation.map(MaskString::keepLastCharacters).orElse(MaskString.DEFAULTS_KEEP_LAST_CHARACTERS)),
                 annotation.map(MaskString::maskCharacter).orElse(MaskString.DEFAULTS_MASK_CHARACTER));
     }
@@ -123,15 +128,15 @@ public class MaskStringSerializer extends JsonSerializer<Object> implements Cont
         Object newValue;
         if (Masked.isEnabled(serializers)) {
             if (value instanceof String) {
-                newValue = MaskUtils.mask((String) value, this.keepLastCharacters, this.maskCharacter);
+                newValue = MaskUtils.mask((String) value, this.keepFirstCharacters, this.keepLastCharacters, this.maskCharacter);
             } else if (value.getClass().isArray()) {
-                newValue = MaskUtils.mask((String[]) value, this.keepLastCharacters, this.maskCharacter);
+                newValue = MaskUtils.mask((String[]) value, this.keepFirstCharacters, this.keepLastCharacters, this.maskCharacter);
             } else if (value instanceof List) {
-                newValue = MaskUtils.mask((List<String>) value, this.keepLastCharacters, this.maskCharacter);
+                newValue = MaskUtils.mask((List<String>) value, this.keepFirstCharacters, this.keepLastCharacters, this.maskCharacter);
             } else if (value instanceof Set) {
-                newValue = MaskUtils.mask((Set<String>) value, this.keepLastCharacters, this.maskCharacter);
+                newValue = MaskUtils.mask((Set<String>) value, this.keepFirstCharacters, this.keepLastCharacters, this.maskCharacter);
             } else if (value instanceof Map) {
-                newValue = MaskUtils.maskMapValues((Map<?, String>) value, this.keepLastCharacters, this.maskCharacter);
+                newValue = MaskUtils.maskMapValues((Map<?, String>) value, this.keepFirstCharacters, this.keepLastCharacters, this.maskCharacter);
             } else {
                 // ups!! value type is not supported :(
                 newValue = value;
@@ -145,7 +150,7 @@ public class MaskStringSerializer extends JsonSerializer<Object> implements Cont
     private JsonSerializer<Object> wrappedResultOrElseNull(final Supplier<JsonSerializer<?>> supplier) {
         return Optional.ofNullable(supplier.get())
                 .map(JsonSerializer.class::cast)
-                .map(ser -> new MaskStringSerializer(ser, this.keepLastCharacters, this.maskCharacter))
+                .map(ser -> new MaskStringSerializer(ser, this.keepFirstCharacters, this.keepLastCharacters, this.maskCharacter))
                 .orElse(null);
     }
 }

--- a/src/test/java/com/github/javiercanillas/jackson/masker/MaskUtilsTest.java
+++ b/src/test/java/com/github/javiercanillas/jackson/masker/MaskUtilsTest.java
@@ -18,34 +18,42 @@ class MaskUtilsTest {
 
     private static Stream<Arguments> stringArguments() {
         return Stream.of(
-                Arguments.of(null, 0, '*', null),
-                Arguments.of("a", 0, '*', "*"),
-                Arguments.of("a", 1, '*', "a"),
-                Arguments.of("abc", 1, '*', "**c")
+                Arguments.of(null, 0, 0, '*', null),
+                Arguments.of(null, 1, 0, '*', null),
+                Arguments.of(null, 0, 1, '*', null),
+                Arguments.of(null, 1, 1, '*', null),
+                Arguments.of("a", 0, 0, '*', "*"),
+                Arguments.of("a", 0, 1, '*', "a"),
+                Arguments.of("a", 1, 0, '*', "a"),
+                Arguments.of("a", 1, 1, '*', "a"),
+                Arguments.of("abc", 0, 1, '*', "**c"),
+                Arguments.of("abc", 1, 0, '*', "a**"),
+                Arguments.of("abc", 1, 1, '*', "a*c"),
+                Arguments.of("abcde", 2, 1, '*', "ab**e")
         );
     }
 
     @ParameterizedTest
     @MethodSource("stringArguments")
-    void mask(String value, int keepLast, char maskChar, String result) {
-        assertEquals(result, MaskUtils.mask(value, keepLast, maskChar));
+    void mask(String value, int keepFirsts, int keepLast, char maskChar, String result) {
+        assertEquals(result, MaskUtils.mask(value, keepFirsts, keepLast, maskChar));
     }
 
     private static Stream<Arguments> stringArrayArguments() {
         return Stream.of(
-                Arguments.of(null, 0, '*', null),
-                Arguments.of(new String[0], 0, '*', new String[0]),
-                Arguments.of(new String[1], 0, '*', new String[1]),
-                Arguments.of(new String[]{"a"}, 1, '*', new String[]{"a"}),
-                Arguments.of(new String[]{"a", null}, 1, '*', new String[]{"a", null}),
-                Arguments.of(new String[]{"abc", "a"}, 1, '*', new String[]{"**c", "a"})
+                Arguments.of(null, 0, 0, '*', null),
+                Arguments.of(new String[0], 0, 0, '*', new String[0]),
+                Arguments.of(new String[1], 0, 0, '*', new String[1]),
+                Arguments.of(new String[]{"a"}, 0, 1, '*', new String[]{"a"}),
+                Arguments.of(new String[]{"a", null}, 0, 1, '*', new String[]{"a", null}),
+                Arguments.of(new String[]{"abc", "a"}, 0, 1, '*', new String[]{"**c", "a"})
         );
     }
 
     @ParameterizedTest
     @MethodSource("stringArrayArguments")
-    void mask(String[] value, int keepLast, char maskChar, String[] result) {
-        final String[] masked = MaskUtils.mask(value, keepLast, maskChar);
+    void mask(String[] value, int keepFirst, int keepLast, char maskChar, String[] result) {
+        final String[] masked = MaskUtils.mask(value, keepFirst, keepLast, maskChar);
         if (value == null) {
             assertNull(masked);
         } else {
@@ -57,17 +65,17 @@ class MaskUtilsTest {
 
     private static Stream<Arguments> stringListArguments() {
         return Stream.of(
-                Arguments.of(null, 0, '*', null),
-                Arguments.of(List.of(), 0, '*', List.of()),
-                Arguments.of(List.of("a"), 1, '*', List.of("a")),
-                Arguments.of(List.of("abc", "a"), 1, '*', List.of("**c", "a"))
+                Arguments.of(null, 0, 0, '*', null),
+                Arguments.of(List.of(), 0, 0, '*', List.of()),
+                Arguments.of(List.of("a"), 0, 1, '*', List.of("a")),
+                Arguments.of(List.of("abc", "a"), 0, 1, '*', List.of("**c", "a"))
         );
     }
 
     @ParameterizedTest
     @MethodSource("stringListArguments")
-    void mask(List<String> value, int keepLast, char maskChar, List<String> result) {
-        final List<String> masked = MaskUtils.mask(value, keepLast, maskChar);
+    void mask(List<String> value, int keepFirst, int keepLast, char maskChar, List<String> result) {
+        final List<String> masked = MaskUtils.mask(value, keepFirst, keepLast, maskChar);
         if (value == null) {
             assertNull(masked);
         } else {
@@ -79,17 +87,17 @@ class MaskUtilsTest {
 
     private static Stream<Arguments> stringSetArguments() {
         return Stream.of(
-                Arguments.of(null, 0, '*', null),
-                Arguments.of(Set.of(), 0, '*', Set.of()),
-                Arguments.of(Set.of("a"), 1, '*', Set.of("a")),
-                Arguments.of(Set.of("abc", "a"), 1, '*', Set.of("**c", "a"))
+                Arguments.of(null, 0, 0, '*', null),
+                Arguments.of(Set.of(), 0, 0, '*', Set.of()),
+                Arguments.of(Set.of("a"), 0, 1, '*', Set.of("a")),
+                Arguments.of(Set.of("abc", "a"), 0, 1, '*', Set.of("**c", "a"))
         );
     }
 
     @ParameterizedTest
     @MethodSource("stringSetArguments")
-    void mask(Set<String> value, int keepLast, char maskChar, Set<String> result) {
-        final Set<String> masked = MaskUtils.mask(value, keepLast, maskChar);
+    void mask(Set<String> value, int keepFirst, int keepLast, char maskChar, Set<String> result) {
+        final Set<String> masked = MaskUtils.mask(value, keepFirst, keepLast, maskChar);
         if (value == null) {
             assertNull(masked);
         } else {
@@ -101,20 +109,20 @@ class MaskUtilsTest {
 
     private static Stream<Arguments> stringValueMapArguments() {
         return Stream.of(
-                Arguments.of(null, 0, '*', null),
-                Arguments.of(Map.of(), 0, '*', Map.of()),
-                Arguments.of(Map.of("a", "b"), 1, '*', Map.of("a", "b")),
-                Arguments.of(Map.of(1, "b"), 1, '*', Map.of(1, "b")),
-                Arguments.of(Map.of("a", "bcd"), 1, '*', Map.of("a", "**d")),
-                Arguments.of(Map.of(1, "bcd", 3L, "fgh"), 1, '*', Map.of(1, "**d", 3l, "**h")),
-                Arguments.of(Map.of(BigDecimal.ONE, "bcd", 3L, "fgh"), 1, '*', Map.of(BigDecimal.ONE, "**d", 3L, "**h"))
+                Arguments.of(null, 0, 0, '*', null),
+                Arguments.of(Map.of(), 0, 0, '*', Map.of()),
+                Arguments.of(Map.of("a", "b"), 0, 1, '*', Map.of("a", "b")),
+                Arguments.of(Map.of(1, "b"), 0, 1, '*', Map.of(1, "b")),
+                Arguments.of(Map.of("a", "bcd"), 0, 1, '*', Map.of("a", "**d")),
+                Arguments.of(Map.of(1, "bcd", 3L, "fgh"), 0, 1, '*', Map.of(1, "**d", 3l, "**h")),
+                Arguments.of(Map.of(BigDecimal.ONE, "bcd", 3L, "fgh"), 0, 1, '*', Map.of(BigDecimal.ONE, "**d", 3L, "**h"))
         );
     }
 
     @ParameterizedTest
     @MethodSource("stringValueMapArguments")
-    void mask(Map<?, String> value, int keepLast, char maskChar, Map<?, String> result) {
-        final Map<?, String> masked = MaskUtils.maskMapValues(value, keepLast, maskChar);
+    void mask(Map<?, String> value, int keepFirst, int keepLast, char maskChar, Map<?, String> result) {
+        final Map<?, String> masked = MaskUtils.maskMapValues(value, keepFirst, keepLast, maskChar);
         if (value == null) {
             assertNull(masked);
         } else {
@@ -125,6 +133,7 @@ class MaskUtilsTest {
 
     @Test
     void maskIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> MaskUtils.mask("abc", -1, '*'));
+        assertThrows(IllegalArgumentException.class, () -> MaskUtils.mask("abc", -1, -1, '*'));
+        assertThrows(IllegalArgumentException.class, () -> MaskUtils.mask("abc", 0, -1, '*'));
     }
 }

--- a/src/test/java/com/github/javiercanillas/jackson/masker/examples/ObjectWithStringFieldTest.java
+++ b/src/test/java/com/github/javiercanillas/jackson/masker/examples/ObjectWithStringFieldTest.java
@@ -23,8 +23,12 @@ class ObjectWithStringFieldTest {
         private String sensitiveString;
         @MaskString(keepLastCharacters = 6)
         private String sensitiveStringKeepLastCharacters;
+        @MaskString(keepFirstCharacters = 1)
+        private String sensitiveStringKeepFirstCharacters;
         @MaskString(keepLastCharacters = 6, maskCharacter = '#')
         private String sensitiveStringKeepLastCharactersWithCustomMask;
+        @MaskString(keepFirstCharacters = 1, keepLastCharacters = 6, maskCharacter = '#')
+        private String sensitiveStringKeepFirstKeepLastCharactersWithCustomMask;
     }
 
     private static TestObject buildTestObject(String stringValue) {
@@ -32,7 +36,9 @@ class ObjectWithStringFieldTest {
         obj = new TestObject();
         obj.setSensitiveString(stringValue);
         obj.setSensitiveStringKeepLastCharacters(stringValue);
+        obj.setSensitiveStringKeepFirstCharacters(stringValue);
         obj.setSensitiveStringKeepLastCharactersWithCustomMask(stringValue);
+        obj.setSensitiveStringKeepFirstKeepLastCharactersWithCustomMask(stringValue);
         obj.setStringValue(stringValue);
         return obj;
     }
@@ -40,14 +46,14 @@ class ObjectWithStringFieldTest {
     private static Stream<Arguments> arguments() {
         return Stream.of(
                 Arguments.of(buildTestObject("aabbccdd"),
-                        "{\"stringValue\":\"aabbccdd\",\"sensitiveString\":\"********\",\"sensitiveStringKeepLastCharacters\":\"**bbccdd\",\"sensitiveStringKeepLastCharactersWithCustomMask\":\"##bbccdd\"}",
-                        "{\"stringValue\":\"aabbccdd\",\"sensitiveString\":\"aabbccdd\",\"sensitiveStringKeepLastCharacters\":\"aabbccdd\",\"sensitiveStringKeepLastCharactersWithCustomMask\":\"aabbccdd\"}"),
+                        "{\"stringValue\":\"aabbccdd\",\"sensitiveString\":\"********\",\"sensitiveStringKeepLastCharacters\":\"**bbccdd\",\"sensitiveStringKeepFirstCharacters\":\"a*******\",\"sensitiveStringKeepLastCharactersWithCustomMask\":\"##bbccdd\",\"sensitiveStringKeepFirstKeepLastCharactersWithCustomMask\":\"a#bbccdd\"}",
+                        "{\"stringValue\":\"aabbccdd\",\"sensitiveString\":\"aabbccdd\",\"sensitiveStringKeepLastCharacters\":\"aabbccdd\",\"sensitiveStringKeepFirstCharacters\":\"aabbccdd\",\"sensitiveStringKeepLastCharactersWithCustomMask\":\"aabbccdd\",\"sensitiveStringKeepFirstKeepLastCharactersWithCustomMask\":\"aabbccdd\"}"),
                 Arguments.of(buildTestObject("aabb"),
-                        "{\"stringValue\":\"aabb\",\"sensitiveString\":\"****\",\"sensitiveStringKeepLastCharacters\":\"aabb\",\"sensitiveStringKeepLastCharactersWithCustomMask\":\"aabb\"}",
-                        "{\"stringValue\":\"aabb\",\"sensitiveString\":\"aabb\",\"sensitiveStringKeepLastCharacters\":\"aabb\",\"sensitiveStringKeepLastCharactersWithCustomMask\":\"aabb\"}"),
+                        "{\"stringValue\":\"aabb\",\"sensitiveString\":\"****\",\"sensitiveStringKeepLastCharacters\":\"aabb\",\"sensitiveStringKeepFirstCharacters\":\"a***\",\"sensitiveStringKeepLastCharactersWithCustomMask\":\"aabb\",\"sensitiveStringKeepFirstKeepLastCharactersWithCustomMask\":\"aabb\"}",
+                        "{\"stringValue\":\"aabb\",\"sensitiveString\":\"aabb\",\"sensitiveStringKeepLastCharacters\":\"aabb\",\"sensitiveStringKeepFirstCharacters\":\"aabb\",\"sensitiveStringKeepLastCharactersWithCustomMask\":\"aabb\",\"sensitiveStringKeepFirstKeepLastCharactersWithCustomMask\":\"aabb\"}"),
                 Arguments.of(buildTestObject(null),
-                        "{\"stringValue\":null,\"sensitiveString\":null,\"sensitiveStringKeepLastCharacters\":null,\"sensitiveStringKeepLastCharactersWithCustomMask\":null}",
-                        "{\"stringValue\":null,\"sensitiveString\":null,\"sensitiveStringKeepLastCharacters\":null,\"sensitiveStringKeepLastCharactersWithCustomMask\":null}")
+                        "{\"stringValue\":null,\"sensitiveString\":null,\"sensitiveStringKeepLastCharacters\":null,\"sensitiveStringKeepFirstCharacters\":null,\"sensitiveStringKeepLastCharactersWithCustomMask\":null,\"sensitiveStringKeepFirstKeepLastCharactersWithCustomMask\":null}",
+                        "{\"stringValue\":null,\"sensitiveString\":null,\"sensitiveStringKeepLastCharacters\":null,\"sensitiveStringKeepFirstCharacters\":null,\"sensitiveStringKeepLastCharactersWithCustomMask\":null,\"sensitiveStringKeepFirstKeepLastCharactersWithCustomMask\":null}")
         );
     }
 

--- a/src/test/java/com/github/javiercanillas/jackson/masker/examples/ObjectWithUnsupportedFieldTest.java
+++ b/src/test/java/com/github/javiercanillas/jackson/masker/examples/ObjectWithUnsupportedFieldTest.java
@@ -1,0 +1,56 @@
+package com.github.javiercanillas.jackson.masker.examples;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.javiercanillas.jackson.masker.annotation.MaskString;
+import com.github.javiercanillas.jackson.masker.view.Masked;
+import lombok.Data;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+
+class ObjectWithUnsupportedFieldTest {
+
+    @Data
+    public static class TestObject {
+
+        private Boolean booleanValue;
+        @MaskString
+        private Boolean sensitiveBoolean;
+    }
+
+    private static TestObject buildTestObject(Boolean booleanValue) {
+        TestObject obj;
+        obj = new TestObject();
+        obj.setBooleanValue(booleanValue);
+        obj.setSensitiveBoolean(booleanValue);
+        return obj;
+    }
+
+    private static Stream<Arguments> arguments() {
+        return Stream.of(
+                Arguments.of(buildTestObject(Boolean.TRUE),
+                        "{\"booleanValue\":true,\"sensitiveBoolean\":true}",
+                        "{\"booleanValue\":true,\"sensitiveBoolean\":true}"),
+                Arguments.of(buildTestObject(Boolean.TRUE),
+                        "{\"booleanValue\":true,\"sensitiveBoolean\":true}",
+                        "{\"booleanValue\":true,\"sensitiveBoolean\":true}"),
+                Arguments.of(buildTestObject(null),
+                        "{\"booleanValue\":null,\"sensitiveBoolean\":null}",
+                        "{\"booleanValue\":null,\"sensitiveBoolean\":null}")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("arguments")
+    void map(TestObject obj, String maskedStringOutput, String normalStringOutput) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Assertions.assertEquals(maskedStringOutput, mapper.writerWithView(Masked.class).writeValueAsString(obj));
+        Assertions.assertEquals(normalStringOutput, mapper.writer().writeValueAsString(obj));
+    }
+}

--- a/src/test/java/com/github/javiercanillas/jackson/masker/ser/MaskStringSerializerTest.java
+++ b/src/test/java/com/github/javiercanillas/jackson/masker/ser/MaskStringSerializerTest.java
@@ -27,6 +27,7 @@ class MaskStringSerializerTest {
 
     MaskStringSerializer maskStringSerializerNoArgs;
     MaskStringSerializer maskStringSerializerArgs;
+    final int keepFirstCharacters = 0;
     final int keepLastCharacters = 0;
     final char maskCharacter = '*';
 
@@ -37,7 +38,8 @@ class MaskStringSerializerTest {
     @BeforeEach
     void setup() {
         this.maskStringSerializerNoArgs = new MaskStringSerializer();
-        this.maskStringSerializerArgs = new MaskStringSerializer(this.innerSerializer, this.keepLastCharacters, this.maskCharacter);
+        this.maskStringSerializerArgs = new MaskStringSerializer(this.innerSerializer, this.keepFirstCharacters,
+                this.keepLastCharacters, this.maskCharacter);
     }
     @Test
     void unwrappingSerializer() {
@@ -61,6 +63,7 @@ class MaskStringSerializerTest {
         assertEquals(MaskStringSerializer.class, serializer.getClass());
         final var maskStringSerializer = (MaskStringSerializer) serializer;
         assertEquals(this.maskStringSerializerArgs.getMaskCharacter(), maskStringSerializer.getMaskCharacter());
+        assertEquals(this.maskStringSerializerArgs.getKeepFirstCharacters(), maskStringSerializer.getKeepFirstCharacters());
         assertEquals(this.maskStringSerializerArgs.getKeepLastCharacters(), maskStringSerializer.getKeepLastCharacters());
         assertEquals(mockedSerializer, maskStringSerializer.getNonMaskerSerializer());
 
@@ -78,6 +81,7 @@ class MaskStringSerializerTest {
         assertEquals(MaskStringSerializer.class, serializer.getClass());
         final var maskStringSerializer = (MaskStringSerializer) serializer;
         assertEquals(this.maskStringSerializerArgs.getMaskCharacter(), maskStringSerializer.getMaskCharacter());
+        assertEquals(this.maskStringSerializerArgs.getKeepFirstCharacters(), maskStringSerializer.getKeepFirstCharacters());
         assertEquals(this.maskStringSerializerArgs.getKeepLastCharacters(), maskStringSerializer.getKeepLastCharacters());
         assertEquals(mockedSerializer, maskStringSerializer.getNonMaskerSerializer());
 
@@ -139,6 +143,7 @@ class MaskStringSerializerTest {
         assertEquals(MaskStringSerializer.class, delegatee.getClass());
         final var maskStringSerializerDelegatee = (MaskStringSerializer) delegatee;
         assertEquals(this.maskStringSerializerArgs.getMaskCharacter(), maskStringSerializerDelegatee.getMaskCharacter());
+        assertEquals(this.maskStringSerializerArgs.getKeepFirstCharacters(), maskStringSerializerDelegatee.getKeepFirstCharacters());
         assertEquals(this.maskStringSerializerArgs.getKeepLastCharacters(), maskStringSerializerDelegatee.getKeepLastCharacters());
         assertEquals(mockedSerializer, maskStringSerializerDelegatee.getNonMaskerSerializer());
         verify(innerSerializer, times(1)).getDelegatee();


### PR DESCRIPTION
New attribute added to `MaskString` annotation called: `keepFirstCharacters` to enable more customization on masking logic.